### PR TITLE
Rails Behavior Tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /spec/reports/
 /tmp/
 Gemfile.lock
+*~

--- a/lib/composite_cache_store/version.rb
+++ b/lib/composite_cache_store/version.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
-class CompositeCacheStore
+require "active_support/cache"
+
+class CompositeCacheStore < ActiveSupport::Cache::Store
   VERSION = "0.0.3"
 end

--- a/test/behaviors/cache_increment_decrement_behavior.rb
+++ b/test/behaviors/cache_increment_decrement_behavior.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module CacheIncrementDecrementBehavior
+  def test_increment
+    key = SecureRandom.uuid
+    @cache.write(key, 1, raw: true)
+    assert_equal 1, @cache.read(key, raw: true).to_i
+    assert_equal 2, @cache.increment(key)
+    assert_equal 2, @cache.read(key, raw: true).to_i
+    assert_equal 3, @cache.increment(key)
+    assert_equal 3, @cache.read(key, raw: true).to_i
+
+    missing = @cache.increment(SecureRandom.alphanumeric)
+    assert_equal 1, missing
+    missing = @cache.increment(SecureRandom.alphanumeric, 100)
+    assert_equal 100, missing
+  end
+
+  def test_decrement
+    key = SecureRandom.uuid
+    @cache.write(key, 3, raw: true)
+    assert_equal 3, @cache.read(key, raw: true).to_i
+    assert_equal 2, @cache.decrement(key)
+    assert_equal 2, @cache.read(key, raw: true).to_i
+    assert_equal 1, @cache.decrement(key)
+    assert_equal 1, @cache.read(key, raw: true).to_i
+
+    missing = @cache.decrement(SecureRandom.alphanumeric)
+    assert_equal @cache.is_a?(ActiveSupport::Cache::MemCacheStore) ? 0 : -1, missing
+    missing = @cache.decrement(SecureRandom.alphanumeric, 100)
+    assert_equal @cache.is_a?(ActiveSupport::Cache::MemCacheStore) ? 0 : -100, missing
+  end
+end

--- a/test/behaviors/cache_instrumentation_behavior.rb
+++ b/test/behaviors/cache_instrumentation_behavior.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+module CacheInstrumentationBehavior
+  def test_fetch_multi_uses_write_multi_entries_store_provider_interface
+    assert_called(@cache, :write_multi_entries) do
+      @cache.fetch_multi "a", "b", "c" do |key|
+        key * 2
+      end
+    end
+  end
+
+  def test_write_multi_instrumentation
+    key_1 = SecureRandom.uuid
+    key_2 = SecureRandom.uuid
+    value_1 = SecureRandom.alphanumeric
+    value_2 = SecureRandom.alphanumeric
+    writes = { key_1 => value_1, key_2 => value_2 }
+
+    events = with_instrumentation "write_multi" do
+      @cache.write_multi(writes)
+    end
+
+    assert_equal %w[ cache_write_multi.active_support ], events.map(&:name)
+    assert_nil events[0].payload[:super_operation]
+    assert_equal({ key_1 => value_1, key_2 => value_2 }, events[0].payload[:key])
+  end
+
+  def test_instrumentation_with_fetch_multi_as_super_operation
+    key_1 = SecureRandom.uuid
+    @cache.write(key_1, SecureRandom.alphanumeric)
+
+    key_2 = SecureRandom.uuid
+
+    events = with_instrumentation "read_multi" do
+      @cache.fetch_multi(key_2, key_1) { |key| key * 2 }
+    end
+
+    assert_equal %w[ cache_read_multi.active_support ], events.map(&:name)
+    assert_equal :fetch_multi, events[0].payload[:super_operation]
+    assert_equal [key_2, key_1], events[0].payload[:key]
+    assert_equal [key_1], events[0].payload[:hits]
+    assert_equal @cache.class.name, events[0].payload[:store]
+  end
+
+  def test_instrumentation_empty_fetch_multi
+    events = with_instrumentation "read_multi" do
+      @cache.fetch_multi() { |key| key * 2 }
+    end
+
+    assert_equal %w[ cache_read_multi.active_support ], events.map(&:name)
+    assert_equal :fetch_multi, events[0].payload[:super_operation]
+    assert_equal [], events[0].payload[:key]
+    assert_equal [], events[0].payload[:hits]
+    assert_equal @cache.class.name, events[0].payload[:store]
+  end
+
+  def test_read_multi_instrumentation
+    key_1 = SecureRandom.uuid
+    @cache.write(key_1, SecureRandom.alphanumeric)
+
+    key_2 = SecureRandom.uuid
+
+    events = with_instrumentation "read_multi" do
+      @cache.read_multi(key_2, key_1)
+    end
+
+    assert_equal %w[ cache_read_multi.active_support ], events.map(&:name)
+    assert_equal [key_2, key_1], events[0].payload[:key]
+    assert_equal [key_1], events[0].payload[:hits]
+    assert_equal @cache.class.name, events[0].payload[:store]
+  end
+
+  def test_empty_read_multi_instrumentation
+    events = with_instrumentation "read_multi" do
+      @cache.read_multi()
+    end
+
+    assert_equal %w[ cache_read_multi.active_support ], events.map(&:name)
+    assert_equal [], events[0].payload[:key]
+    assert_equal [], events[0].payload[:hits]
+    assert_equal @cache.class.name, events[0].payload[:store]
+  end
+
+  private
+    def with_instrumentation(method)
+      event_name = "cache_#{method}.active_support"
+
+      [].tap do |events|
+        ActiveSupport::Notifications.subscribe event_name do |*args|
+          events << ActiveSupport::Notifications::Event.new(*args)
+        end
+        yield
+      end
+    ensure
+      ActiveSupport::Notifications.unsubscribe event_name
+    end
+end

--- a/test/behaviors/cache_store_behavior.rb
+++ b/test/behaviors/cache_store_behavior.rb
@@ -1,0 +1,810 @@
+# frozen_string_literal: true
+
+require "active_support/core_ext/numeric/time"
+
+# Tests the base functionality that should be identical across all cache stores.
+module CacheStoreBehavior
+  def test_should_read_and_write_strings
+    key = SecureRandom.uuid
+    assert @cache.write(key, "bar")
+    assert_equal "bar", @cache.read(key)
+  end
+
+  def test_should_overwrite
+    key = SecureRandom.uuid
+    @cache.write(key, "bar")
+    @cache.write(key, "baz")
+    assert_equal "baz", @cache.read(key)
+  end
+
+  def test_fetch_without_cache_miss
+    key = SecureRandom.uuid
+    @cache.write(key, "bar")
+    assert_not_called(@cache, :write) do
+      assert_equal "bar", @cache.fetch(key) { "baz" }
+    end
+  end
+
+  def test_fetch_with_cache_miss
+    key = SecureRandom.uuid
+    assert_called_with(@cache, :write, [key, "baz", @cache.options]) do
+      assert_equal "baz", @cache.fetch(key) { "baz" }
+    end
+  end
+
+  def test_fetch_with_cache_miss_passes_key_to_block
+    cache_miss = false
+    key = SecureRandom.alphanumeric(10)
+    assert_equal 10, @cache.fetch(key) { |key| cache_miss = true; key.length }
+    assert cache_miss
+
+    cache_miss = false
+    assert_equal 10, @cache.fetch(key) { |fetch_key| cache_miss = true; fetch_key.length }
+    assert_not cache_miss
+  end
+
+  def test_fetch_with_dynamic_options
+    key = SecureRandom.uuid
+    expiry = 10.minutes.from_now
+    expected_options = @cache.options.dup
+    expected_options.delete(:expires_in)
+    expected_options.merge!(
+      expires_at: expiry,
+      version: "v42",
+    )
+
+    assert_called_with(@cache, :write, [key, "bar", expected_options]) do
+      @cache.fetch(key) do |key, options|
+        assert_equal @cache.options[:expires_in], options.expires_in
+        assert_nil options.expires_at
+        assert_nil options.version
+
+        options.expires_at = expiry
+        options.version = "v42"
+
+        assert_nil options.expires_in
+        assert_equal expiry, options.expires_at
+        assert_equal "v42", options.version
+
+        "bar"
+      end
+    end
+  end
+
+  def test_fetch_with_forced_cache_miss
+    key = SecureRandom.uuid
+    @cache.write(key, "bar")
+    assert_not_called(@cache, :read) do
+      assert_called_with(@cache, :write, [key, "bar", @cache.options.merge(force: true)]) do
+        @cache.fetch(key, force: true) { "bar" }
+      end
+    end
+  end
+
+  def test_fetch_with_cached_nil
+    key = SecureRandom.uuid
+    @cache.write(key, nil)
+    assert_not_called(@cache, :write) do
+      assert_nil @cache.fetch(key) { "baz" }
+    end
+  end
+
+  def test_fetch_cache_miss_with_skip_nil
+    key = SecureRandom.uuid
+    assert_not_called(@cache, :write) do
+      assert_nil @cache.fetch(key, skip_nil: true) { nil }
+      assert_equal false, @cache.exist?("foo")
+    end
+  end
+
+  def test_fetch_with_forced_cache_miss_with_block
+    key = SecureRandom.uuid
+    @cache.write(key, "bar")
+    assert_equal "foo_bar", @cache.fetch(key, force: true) { "foo_bar" }
+  end
+
+  def test_fetch_with_forced_cache_miss_without_block
+    key = SecureRandom.uuid
+    @cache.write(key, "bar")
+    assert_raises(ArgumentError) do
+      @cache.fetch(key, force: true)
+    end
+
+    assert_equal "bar", @cache.read(key)
+  end
+
+  def test_should_read_and_write_hash
+    key = SecureRandom.uuid
+    assert @cache.write(key, a: "b")
+    assert_equal({ a: "b" }, @cache.read(key))
+  end
+
+  def test_should_read_and_write_integer
+    key = SecureRandom.uuid
+    assert @cache.write(key, 1)
+    assert_equal 1, @cache.read(key)
+  end
+
+  def test_should_read_and_write_nil
+    key = SecureRandom.uuid
+    assert @cache.write(key, nil)
+    assert_nil @cache.read(key)
+  end
+
+  def test_should_read_and_write_false
+    key = SecureRandom.uuid
+    assert @cache.write(key, false)
+    assert_equal false, @cache.read(key)
+  end
+
+  def test_read_multi
+    key = SecureRandom.uuid
+    @cache.write(key, "bar")
+    other_key = SecureRandom.uuid
+    @cache.write(other_key, "baz")
+    @cache.write(SecureRandom.alphanumeric, "biz")
+    assert_equal({ key => "bar", other_key => "baz" }, @cache.read_multi(key, other_key))
+  end
+
+  def test_read_multi_with_expires
+    time = Time.now
+    key = SecureRandom.uuid
+    other_key = SecureRandom.uuid
+    @cache.write(key, "bar", expires_in: 10)
+    @cache.write(other_key, "baz")
+    @cache.write(SecureRandom.alphanumeric, "biz")
+    Time.stub(:now, time + 11) do
+      assert_equal({ other_key => "baz" }, @cache.read_multi(other_key, SecureRandom.alphanumeric))
+    end
+  end
+
+  def test_read_multi_with_empty_keys_and_a_logger_and_no_namespace
+    cache = lookup_store(namespace: nil)
+    cache.logger = ActiveSupport::Logger.new(nil)
+    assert_equal({}, cache.read_multi)
+  end
+
+  def test_fetch_multi
+    key = SecureRandom.uuid
+    other_key = SecureRandom.uuid
+    third_key = SecureRandom.alphanumeric
+    @cache.write(key, "bar")
+    @cache.write(other_key, "biz")
+
+    values = @cache.fetch_multi(key, other_key, third_key) { |value| value * 2 }
+
+    assert_equal({ key => "bar", other_key => "biz", third_key => (third_key * 2) }, values)
+    assert_equal((third_key * 2), @cache.read(third_key))
+  end
+
+  def test_fetch_multi_without_expires_in
+    key = SecureRandom.uuid
+    other_key = SecureRandom.uuid
+    third_key = SecureRandom.alphanumeric
+    @cache.write(key, "bar")
+    @cache.write(other_key, "biz")
+
+    values = @cache.fetch_multi(key, third_key, other_key, expires_in: nil) { |value| value * 2 }
+
+    assert_equal({ key => "bar", third_key => (third_key * 2), other_key => "biz" }, values)
+    assert_equal((third_key * 2), @cache.read(third_key))
+  end
+
+  def test_fetch_multi_with_objects
+    key = SecureRandom.uuid
+    other_key = SecureRandom.uuid
+    cache_struct = Struct.new(:cache_key, :title)
+    foo = cache_struct.new(key, "FOO!")
+    bar = cache_struct.new(other_key)
+
+    @cache.write(other_key, "BAM!")
+
+    values = @cache.fetch_multi(foo, bar) { |object| object.title }
+
+    assert_equal({ foo => "FOO!", bar => "BAM!" }, values)
+  end
+
+  def test_fetch_multi_returns_ordered_names
+    key = SecureRandom.alphanumeric.downcase
+    other_key = SecureRandom.alphanumeric.downcase
+    third_key = SecureRandom.alphanumeric.downcase
+    @cache.write(key, "BAM")
+
+    values = @cache.fetch_multi(other_key, third_key, key) { |key| key.upcase }
+
+    assert_equal([other_key, third_key, key], values.keys)
+    assert_equal([other_key.upcase, third_key.upcase, "BAM"], values.values)
+  end
+
+  def test_fetch_multi_without_block
+    assert_raises(ArgumentError) do
+      @cache.fetch_multi(SecureRandom.alphanumeric)
+    end
+  end
+
+  def test_fetch_multi_with_forced_cache_miss
+    key = SecureRandom.uuid
+    other_key = SecureRandom.uuid
+    @cache.write(key, "bar")
+
+    values = @cache.fetch_multi(key, other_key, force: true) { |value| value * 2 }
+
+    assert_equal({ key => (key * 2), other_key => (other_key * 2) }, values)
+    assert_equal(key * 2, @cache.read(key))
+    assert_equal(other_key * 2, @cache.read(other_key))
+  end
+
+  def test_fetch_multi_with_skip_nil
+    key = SecureRandom.uuid
+    other_key = SecureRandom.uuid
+
+    values = @cache.fetch_multi(key, other_key, skip_nil: true) { |k| k == key ? k : nil }
+
+    assert_equal({ key => key, other_key => nil }, values)
+    assert_equal(false, @cache.exist?(other_key))
+  end
+
+  # Use strings that are guaranteed to compress well, so we can easily tell if
+  # the compression kicked in or not.
+  SMALL_STRING = "0" * 100
+  LARGE_STRING = "0" * 2.kilobytes
+
+  SMALL_OBJECT = { data: SMALL_STRING }
+  LARGE_OBJECT = { data: LARGE_STRING }
+
+  def test_nil_with_default_compression_settings
+    assert_uncompressed(nil)
+  end
+
+  def test_nil_with_compress_true
+    assert_uncompressed(nil, compress: true)
+  end
+
+  def test_nil_with_compress_false
+    assert_uncompressed(nil, compress: false)
+  end
+
+  def test_nil_with_compress_low_compress_threshold
+    assert_uncompressed(nil, compress: true, compress_threshold: 20)
+  end
+
+  def test_small_string_with_default_compression_settings
+    assert_uncompressed(SMALL_STRING)
+  end
+
+  def test_small_string_with_compress_true
+    assert_uncompressed(SMALL_STRING, compress: true)
+  end
+
+  def test_small_string_with_compress_false
+    assert_uncompressed(SMALL_STRING, compress: false)
+  end
+
+  def test_small_string_with_low_compress_threshold
+    assert_compressed(SMALL_STRING, compress: true, compress_threshold: 1)
+  end
+
+  def test_small_object_with_default_compression_settings
+    assert_uncompressed(SMALL_OBJECT)
+  end
+
+  def test_small_object_with_compress_true
+    assert_uncompressed(SMALL_OBJECT, compress: true)
+  end
+
+  def test_small_object_with_compress_false
+    assert_uncompressed(SMALL_OBJECT, compress: false)
+  end
+
+  def test_small_object_with_low_compress_threshold
+    assert_compressed(SMALL_OBJECT, compress: true, compress_threshold: 1)
+  end
+
+  def test_large_string_with_compress_true
+    assert_compressed(LARGE_STRING, compress: true)
+  end
+
+  def test_large_string_with_compress_false
+    assert_uncompressed(LARGE_STRING, compress: false)
+  end
+
+  def test_large_string_with_high_compress_threshold
+    assert_uncompressed(LARGE_STRING, compress: true, compress_threshold: 1.megabyte)
+  end
+
+  def test_large_object_with_compress_true
+    assert_compressed(LARGE_OBJECT, compress: true)
+  end
+
+  def test_large_object_with_compress_false
+    assert_uncompressed(LARGE_OBJECT, compress: false)
+  end
+
+  def test_large_object_with_high_compress_threshold
+    assert_uncompressed(LARGE_OBJECT, compress: true, compress_threshold: 1.megabyte)
+  end
+
+  def test_incompressible_data
+    assert_uncompressed(nil, compress: true, compress_threshold: 30)
+    assert_uncompressed(true, compress: true, compress_threshold: 30)
+    assert_uncompressed(false, compress: true, compress_threshold: 30)
+    assert_uncompressed(0, compress: true, compress_threshold: 30)
+    assert_uncompressed(1.2345, compress: true, compress_threshold: 30)
+    assert_uncompressed("", compress: true, compress_threshold: 30)
+
+    incompressible = nil
+
+    # generate an incompressible string
+    loop do
+      incompressible = Random.bytes(1.kilobyte)
+      break if incompressible.bytesize < Zlib::Deflate.deflate(incompressible).bytesize
+    end
+
+    assert_uncompressed(incompressible, compress: true, compress_threshold: 1)
+  end
+
+  def test_cache_key
+    key = SecureRandom.uuid
+    klass = Class.new do
+      def initialize(key)
+        @key = key
+      end
+      def cache_key
+        @key
+      end
+    end
+    @cache.write(klass.new(key), "bar")
+    assert_equal "bar", @cache.read(key)
+  end
+
+  def test_param_as_cache_key
+    key = SecureRandom.uuid
+    klass = Class.new do
+      def initialize(key)
+        @key = key
+      end
+      def to_param
+        @key
+      end
+    end
+    @cache.write(klass.new(key), "bar")
+    assert_equal "bar", @cache.read(key)
+  end
+
+  def test_unversioned_cache_key
+    key = SecureRandom.uuid
+    klass = Class.new do
+      def initialize(key)
+        @key = key
+      end
+      def cache_key
+        @key
+      end
+      def cache_key_with_version
+        "#{@key}-v1"
+      end
+    end
+    @cache.write(klass.new(key), "bar")
+    assert_equal "bar", @cache.read(key)
+  end
+
+  def test_array_as_cache_key
+    key = SecureRandom.uuid
+    @cache.write([key, "foo"], "bar")
+    assert_equal "bar", @cache.read("#{key}/foo")
+  end
+
+  InstanceTest = Struct.new(:name, :id) do
+    def cache_key
+      "#{name}/#{id}"
+    end
+
+    def to_param
+      "hello"
+    end
+  end
+
+  def test_array_with_single_instance_as_cache_key_uses_cache_key_method
+    key = SecureRandom.alphanumeric
+    other_key = SecureRandom.alphanumeric
+    test_instance_one = InstanceTest.new(key, 1)
+    test_instance_two = InstanceTest.new(other_key, 2)
+
+    @cache.write([test_instance_one], "one")
+    @cache.write([test_instance_two], "two")
+
+    assert_equal "one", @cache.read([test_instance_one])
+    assert_equal "two", @cache.read([test_instance_two])
+  end
+
+  def test_array_with_multiple_instances_as_cache_key_uses_cache_key_method
+    key = SecureRandom.alphanumeric
+    other_key = SecureRandom.alphanumeric
+    third_key = SecureRandom.alphanumeric
+    test_instance_one = InstanceTest.new(key, 1)
+    test_instance_two = InstanceTest.new(other_key, 2)
+    test_instance_three = InstanceTest.new(third_key, 3)
+
+    @cache.write([test_instance_one, test_instance_three], "one")
+    @cache.write([test_instance_two, test_instance_three], "two")
+
+    assert_equal "one", @cache.read([test_instance_one, test_instance_three])
+    assert_equal "two", @cache.read([test_instance_two, test_instance_three])
+  end
+
+  def test_format_of_expanded_key_for_single_instance
+    key = SecureRandom.alphanumeric
+    test_instance_one = InstanceTest.new(key, 1)
+
+    expanded_key = @cache.send(:expanded_key, test_instance_one)
+
+    assert_equal expanded_key, test_instance_one.cache_key
+  end
+
+  def test_format_of_expanded_key_for_single_instance_in_array
+    key = SecureRandom.alphanumeric
+    test_instance_one = InstanceTest.new(key, 1)
+
+    expanded_key = @cache.send(:expanded_key, [test_instance_one])
+
+    assert_equal expanded_key, test_instance_one.cache_key
+  end
+
+  def test_hash_as_cache_key
+    key = SecureRandom.alphanumeric
+    other_key = SecureRandom.alphanumeric
+    @cache.write({ key => 1, other_key => 2 }, "bar")
+    assert_equal "bar", @cache.read({ key => 1, other_key => 2 })
+  end
+
+  def test_keys_are_case_sensitive
+    key = "case_sensitive_key"
+    @cache.write(key, "bar")
+    assert_nil @cache.read(key.upcase)
+  end
+
+  def test_exist
+    key = SecureRandom.alphanumeric
+    @cache.write(key, "bar")
+    assert_equal true, @cache.exist?(key)
+    assert_equal false, @cache.exist?(SecureRandom.uuid)
+  end
+
+  def test_nil_exist
+    key = SecureRandom.alphanumeric
+    @cache.write(key, nil)
+    assert @cache.exist?(key)
+  end
+
+  def test_delete
+    key = SecureRandom.alphanumeric
+    @cache.write(key, "bar")
+    assert @cache.exist?(key)
+    assert @cache.delete(key)
+    assert_not @cache.exist?(key)
+  end
+
+  def test_delete_multi
+    key = SecureRandom.alphanumeric
+    @cache.write(key, "bar")
+    assert @cache.exist?(key)
+    other_key = SecureRandom.alphanumeric
+    @cache.write(other_key, "world")
+    assert @cache.exist?(other_key)
+    assert_equal 2, @cache.delete_multi([key, SecureRandom.uuid, other_key])
+    assert_not @cache.exist?(key)
+    assert_not @cache.exist?(other_key)
+  end
+
+  def test_original_store_objects_should_not_be_immutable
+    bar = +"bar"
+    key = SecureRandom.alphanumeric
+    @cache.write(key, bar)
+    assert_nothing_raised { bar.gsub!(/.*/, "baz") }
+  end
+
+  def test_expires_in
+    time = Time.local(2008, 4, 24)
+
+    key = SecureRandom.alphanumeric
+    other_key = SecureRandom.alphanumeric
+
+    Time.stub(:now, time) do
+      @cache.write(key, "bar", expires_in: 1.minute)
+      @cache.write(other_key, "spam", expires_in: 2.minute)
+      assert_equal "bar", @cache.read(key)
+      assert_equal "spam", @cache.read(other_key)
+    end
+
+    Time.stub(:now, time + 30) do
+      assert_equal "bar", @cache.read(key)
+      assert_equal "spam", @cache.read(other_key)
+    end
+
+    Time.stub(:now, time + 1.minute + 1.second) do
+      assert_nil @cache.read(key)
+      assert_equal "spam", @cache.read(other_key)
+    end
+
+    Time.stub(:now, time + 2.minute + 1.second) do
+      assert_nil @cache.read(key)
+      assert_nil @cache.read(other_key)
+    end
+  end
+
+  def test_expires_at
+    time = Time.local(2008, 4, 24)
+
+    key = SecureRandom.alphanumeric
+    Time.stub(:now, time) do
+      @cache.write(key, "bar", expires_at: time + 15.seconds)
+      assert_equal "bar", @cache.read(key)
+    end
+
+    Time.stub(:now, time + 10) do
+      assert_equal "bar", @cache.read(key)
+    end
+
+    Time.stub(:now, time + 30) do
+      assert_nil @cache.read(key)
+    end
+  end
+
+  def test_expire_in_is_alias_for_expires_in
+    time = Time.local(2008, 4, 24)
+
+    key = SecureRandom.alphanumeric
+    Time.stub(:now, time) do
+      @cache.write(key, "bar", expire_in: 20)
+      assert_equal "bar", @cache.read(key)
+    end
+
+    Time.stub(:now, time + 10) do
+      assert_equal "bar", @cache.read(key)
+    end
+
+    Time.stub(:now, time + 21) do
+      assert_nil @cache.read(key)
+    end
+  end
+
+  def test_expired_in_is_alias_for_expires_in
+    time = Time.local(2008, 4, 24)
+
+    key = SecureRandom.alphanumeric
+    Time.stub(:now, time) do
+      @cache.write(key, "bar", expired_in: 20)
+      assert_equal "bar", @cache.read(key)
+    end
+
+    Time.stub(:now, time + 10) do
+      assert_equal "bar", @cache.read(key)
+    end
+
+    Time.stub(:now, time + 21) do
+      assert_nil @cache.read(key)
+    end
+  end
+
+  def test_expires_in_and_expires_at
+    key = SecureRandom.uuid
+    error = assert_raises(ArgumentError) do
+      @cache.write(key, "bar", expire_in: 60, expires_at: 1.minute.from_now)
+    end
+    assert_equal "Either :expires_in or :expires_at can be supplied, but not both", error.message
+  end
+
+  def test_invalid_expiration_time_raises_an_error_when_raise_on_invalid_cache_expiration_time_is_true
+    with_raise_on_invalid_cache_expiration_time(true) do
+      key = SecureRandom.uuid
+      error = assert_raises(ArgumentError) do
+        @cache.write(key, "bar", expires_in: -60)
+      end
+      assert_equal "Cache expiration time is invalid, cannot be negative: -60", error.message
+    end
+  end
+
+  def test_invalid_expiration_time_reports_and_logs_when_raise_on_invalid_cache_expiration_time_is_false
+    with_raise_on_invalid_cache_expiration_time(false) do
+      error_message = "Cache expiration time is invalid, cannot be negative: -60"
+      report = assert_error_reported(ArgumentError) do
+        logs = capture_logs do
+          key = SecureRandom.uuid
+          @cache.write(key, "bar", expires_in: -60)
+        end
+        assert_includes logs, "ArgumentError: #{error_message}"
+      end
+      assert_includes report.error.message, error_message
+    end
+  end
+
+  def test_race_condition_protection_skipped_if_not_defined
+    key = SecureRandom.alphanumeric
+    @cache.write(key, "bar")
+    time = @cache.send(:read_entry, @cache.send(:normalize_key, key, {}), **{}).expires_at
+
+    Time.stub(:now, Time.at(time)) do
+      result = @cache.fetch(key) do
+        assert_nil @cache.read(key)
+        "baz"
+      end
+      assert_equal "baz", result
+    end
+  end
+
+  def test_race_condition_protection_is_limited
+    time = Time.now
+    key = SecureRandom.uuid
+    @cache.write(key, "bar", expires_in: 60)
+    Time.stub(:now, time + 71) do
+      result = @cache.fetch(key, race_condition_ttl: 10) do
+        assert_nil @cache.read(key)
+        "baz"
+      end
+      assert_equal "baz", result
+    end
+  end
+
+  def test_race_condition_protection_is_safe
+    time = Time.now
+    key = SecureRandom.uuid
+    @cache.write(key, "bar", expires_in: 60)
+    Time.stub(:now, time + 61) do
+      begin
+        @cache.fetch(key, race_condition_ttl: 10) do
+          assert_equal "bar", @cache.read(key)
+          raise ArgumentError.new
+        end
+      rescue ArgumentError
+      end
+      assert_equal "bar", @cache.read(key)
+    end
+    Time.stub(:now, time + 91) do
+      assert_nil @cache.read(key)
+    end
+  end
+
+  def test_race_condition_protection
+    time = Time.now
+    key = SecureRandom.uuid
+    @cache.write(key, "bar", expires_in: 60)
+    Time.stub(:now, time + 61) do
+      result = @cache.fetch(key, race_condition_ttl: 10) do
+        assert_equal "bar", @cache.read(key)
+        "baz"
+      end
+      assert_equal "baz", result
+    end
+  end
+
+  def test_fetch_multi_race_condition_protection
+    time = Time.now
+    key = SecureRandom.uuid
+    other_key = SecureRandom.uuid
+    @cache.write(key, "foo", expires_in: 60)
+    @cache.write(other_key, "bar", expires_in: 100)
+    Time.stub(:now, time + 71) do
+      result = @cache.fetch_multi(key, other_key, race_condition_ttl: 10) do
+        assert_nil @cache.read(key)
+        assert_equal "bar", @cache.read(other_key)
+        "baz"
+      end
+      assert_equal({ key => "baz", other_key => "bar" }, result)
+    end
+  end
+
+  def test_absurd_key_characters
+    absurd_key = "#/:*(<+=> )&$%@?;'\"\'`~-"
+    assert @cache.write(absurd_key, "1", raw: true)
+    assert_equal "1", @cache.read(absurd_key, raw: true)
+    assert_equal "1", @cache.fetch(absurd_key, raw: true)
+    assert @cache.delete(absurd_key)
+    assert_equal "2", @cache.fetch(absurd_key, raw: true) { "2" }
+    assert_equal 3, @cache.increment(absurd_key)
+    assert_equal 2, @cache.decrement(absurd_key)
+  end
+
+  def test_really_long_keys
+    key = SecureRandom.alphanumeric * 2048
+    assert @cache.write(key, "bar")
+    assert_equal "bar", @cache.read(key)
+    assert_equal "bar", @cache.fetch(key)
+    assert_nil @cache.read("#{key}x")
+    assert_equal({ key => "bar" }, @cache.read_multi(key))
+  end
+
+  def test_cache_hit_instrumentation
+    key = "test_key"
+    @events = []
+    ActiveSupport::Notifications.subscribe "cache_read.active_support" do |*args|
+      @events << ActiveSupport::Notifications::Event.new(*args)
+    end
+    assert @cache.write(key, "1", raw: true)
+    assert @cache.fetch(key, raw: true) { }
+    assert_equal 1, @events.length
+    assert_equal "cache_read.active_support", @events[0].name
+    assert_equal :fetch, @events[0].payload[:super_operation]
+    assert @events[0].payload[:hit]
+  ensure
+    ActiveSupport::Notifications.unsubscribe "cache_read.active_support"
+  end
+
+  def test_cache_miss_instrumentation
+    @events = []
+    ActiveSupport::Notifications.subscribe(/^cache_(.*)\.active_support$/) do |*args|
+      @events << ActiveSupport::Notifications::Event.new(*args)
+    end
+    assert_not @cache.fetch(SecureRandom.uuid) { }
+    assert_equal 3, @events.length
+    assert_equal "cache_read.active_support", @events[0].name
+    assert_equal "cache_generate.active_support", @events[1].name
+    assert_equal "cache_write.active_support", @events[2].name
+    assert_equal :fetch, @events[0].payload[:super_operation]
+    assert_not @events[0].payload[:hit]
+  ensure
+    ActiveSupport::Notifications.unsubscribe "cache_read.active_support"
+  end
+
+  private
+  def assert_compressed(value, **options)
+    assert_compression(true, value, **options)
+  end
+
+  def assert_uncompressed(value, **options)
+    assert_compression(false, value, **options)
+  end
+
+  def assert_compression(should_compress, value, **options)
+    actual = "actual" + SecureRandom.uuid
+    uncompressed = "uncompressed" + SecureRandom.uuid
+
+    freeze_time do
+      @cache.write(actual, value, options)
+      @cache.write(uncompressed, value, options.merge(compress: false))
+    end
+
+    if value.nil?
+      assert_nil @cache.read(actual)
+      assert_nil @cache.read(uncompressed)
+    else
+      assert_equal value, @cache.read(actual)
+      assert_equal value, @cache.read(uncompressed)
+    end
+
+    actual_entry = @cache.send(:read_entry, @cache.send(:normalize_key, actual, {}), **{})
+    uncompressed_entry = @cache.send(:read_entry, @cache.send(:normalize_key, uncompressed, {}), **{})
+
+    actual_payload = @cache.send(:serialize_entry, actual_entry, **@cache.send(:merged_options, options))
+    uncompressed_payload = @cache.send(:serialize_entry, uncompressed_entry, compress: false)
+
+    actual_size = actual_payload.bytesize
+    uncompressed_size = uncompressed_payload.bytesize
+
+    if should_compress
+      assert_operator actual_size, :<, uncompressed_size, "value should be compressed"
+    else
+      assert_equal uncompressed_size, actual_size, "value should not be compressed"
+    end
+  end
+
+  def with_raise_on_invalid_cache_expiration_time(new_value, &block)
+    old_value = ActiveSupport::Cache::Store.raise_on_invalid_cache_expiration_time
+    ActiveSupport::Cache::Store.raise_on_invalid_cache_expiration_time = new_value
+
+    yield
+  ensure
+    ActiveSupport::Cache::Store.raise_on_invalid_cache_expiration_time = old_value
+  end
+
+  def capture_logs(&block)
+    old_logger = ActiveSupport::Cache::Store.logger
+    log = StringIO.new
+    ActiveSupport::Cache::Store.logger = ActiveSupport::Logger.new(log)
+    begin
+      yield
+      log.string
+    ensure
+      ActiveSupport::Cache::Store.logger = old_logger
+    end
+  end
+end

--- a/test/behaviors/cache_store_coder_behavior.rb
+++ b/test/behaviors/cache_store_coder_behavior.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+module CacheStoreCoderBehavior
+  class SpyCoder
+    attr_reader :dumped_entries, :loaded_entries
+
+    def initialize
+      @dumped_entries = []
+      @loaded_entries = []
+    end
+
+    def dump(entry)
+      @dumped_entries << entry
+      Marshal.dump(entry)
+    end
+
+    def load(payload)
+      entry = Marshal.load(payload)
+      @loaded_entries << entry
+      entry
+    end
+  end
+
+  def test_coder_receive_the_entry_on_write
+    coder = SpyCoder.new
+    @store = lookup_store(coder: coder)
+    @store.write("foo", "bar")
+    assert_equal 1, coder.dumped_entries.size
+    entry = coder.dumped_entries.first
+    assert_instance_of ActiveSupport::Cache::Entry, entry
+    assert_equal "bar", entry.value
+  end
+
+  def test_coder_receive_the_entry_on_read
+    coder = SpyCoder.new
+    @store = lookup_store(coder: coder)
+    @store.write("foo", "bar")
+    @store.read("foo")
+    assert_equal 1, coder.loaded_entries.size
+    entry = coder.loaded_entries.first
+    assert_instance_of ActiveSupport::Cache::Entry, entry
+    assert_equal "bar", entry.value
+  end
+
+  def test_coder_receive_the_entry_on_read_multi
+    coder = SpyCoder.new
+    @store = lookup_store(coder: coder)
+    @store.write_multi({ "foo" => "bar", "egg" => "spam" })
+    @store.read_multi("foo", "egg")
+    assert_equal 2, coder.loaded_entries.size
+    entry = coder.loaded_entries.first
+    assert_instance_of ActiveSupport::Cache::Entry, entry
+    assert_equal "bar", entry.value
+
+    entry = coder.loaded_entries[1]
+    assert_instance_of ActiveSupport::Cache::Entry, entry
+    assert_equal "spam", entry.value
+  end
+
+  def test_coder_receive_the_entry_on_write_multi
+    coder = SpyCoder.new
+    @store = lookup_store(coder: coder)
+    @store.write_multi({ "foo" => "bar", "egg" => "spam" })
+    assert_equal 2, coder.dumped_entries.size
+    entry = coder.dumped_entries.first
+    assert_instance_of ActiveSupport::Cache::Entry, entry
+    assert_equal "bar", entry.value
+
+    entry = coder.dumped_entries[1]
+    assert_instance_of ActiveSupport::Cache::Entry, entry
+    assert_equal "spam", entry.value
+  end
+
+  def test_coder_does_not_receive_the_entry_on_read_miss
+    coder = SpyCoder.new
+    @store = lookup_store(coder: coder)
+    @store.read("foo")
+    assert_equal 0, coder.loaded_entries.size
+  end
+end

--- a/test/behaviors/cache_store_version_behavior.rb
+++ b/test/behaviors/cache_store_version_behavior.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+module CacheStoreVersionBehavior
+  ModelWithKeyAndVersion = Struct.new(:cache_key, :cache_version)
+
+  def test_fetch_with_right_version_should_hit
+    key = SecureRandom.uuid
+    value = SecureRandom.alphanumeric
+
+    @cache.fetch(key, version: 1) { value }
+    assert_equal value, @cache.read(key, version: 1)
+  end
+
+  def test_fetch_with_wrong_version_should_miss
+    key = SecureRandom.uuid
+
+    @cache.fetch(key, version: 1) { SecureRandom.alphanumeric }
+    assert_nil @cache.read(key, version: 2)
+  end
+
+  def test_read_with_right_version_should_hit
+    key = SecureRandom.uuid
+    value = SecureRandom.alphanumeric
+
+    @cache.write(key, value, version: 1)
+    assert_equal value, @cache.read(key, version: 1)
+  end
+
+  def test_read_with_wrong_version_should_miss
+    key = SecureRandom.uuid
+    value = SecureRandom.alphanumeric
+
+    @cache.write(key, value, version: 1)
+    assert_nil @cache.read(key, version: 2)
+  end
+
+  def test_exist_with_right_version_should_be_true
+    key = SecureRandom.uuid
+
+    @cache.write(key, SecureRandom.alphanumeric, version: 1)
+    assert @cache.exist?(key, version: 1)
+  end
+
+  def test_exist_with_wrong_version_should_be_false
+    key = SecureRandom.uuid
+
+    @cache.write(key, SecureRandom.alphanumeric, version: 1)
+    assert_not @cache.exist?(key, version: 2)
+  end
+
+  def test_reading_and_writing_with_model_supporting_cache_version
+    model_name = SecureRandom.alphanumeric
+
+    m1v1 = ModelWithKeyAndVersion.new("#{model_name}/1", 1)
+    m1v2 = ModelWithKeyAndVersion.new("#{model_name}/1", 2)
+
+    value = SecureRandom.alphanumeric
+
+    @cache.write(m1v1, value)
+    assert_equal value, @cache.read(m1v1)
+    assert_nil @cache.read(m1v2)
+  end
+
+  def test_reading_and_writing_with_model_supporting_cache_version_using_nested_key
+    model_name = SecureRandom.alphanumeric
+
+    m1v1 = ModelWithKeyAndVersion.new("#{model_name}/1", 1)
+    m1v2 = ModelWithKeyAndVersion.new("#{model_name}/1", 2)
+
+    value = SecureRandom.alphanumeric
+
+    @cache.write([ "something", m1v1 ], value)
+    assert_equal value, @cache.read([ "something", m1v1 ])
+    assert_nil @cache.read([ "something", m1v2 ])
+  end
+
+  def test_fetching_with_model_supporting_cache_version
+    model_name = SecureRandom.alphanumeric
+
+    m1v1 = ModelWithKeyAndVersion.new("#{model_name}/1", 1)
+    m1v2 = ModelWithKeyAndVersion.new("#{model_name}/1", 2)
+
+    value = SecureRandom.alphanumeric
+    other_value = SecureRandom.alphanumeric
+
+    @cache.fetch(m1v1) { value }
+    assert_equal value, @cache.fetch(m1v1) { other_value }
+    assert_equal other_value, @cache.fetch(m1v2) { other_value }
+  end
+
+  def test_exist_with_model_supporting_cache_version
+    model_name = SecureRandom.alphanumeric
+
+    m1v1 = ModelWithKeyAndVersion.new("#{model_name}/1", 1)
+    m1v2 = ModelWithKeyAndVersion.new("#{model_name}/1", 2)
+
+    value = SecureRandom.alphanumeric
+
+    @cache.write(m1v1, value)
+    assert @cache.exist?(m1v1)
+    assert_not @cache.fetch(m1v2)
+  end
+
+  def test_fetch_multi_with_model_supporting_cache_version
+    model_name = SecureRandom.alphanumeric
+
+    m1v1 = ModelWithKeyAndVersion.new("#{model_name}/1", 1)
+    m2v1 = ModelWithKeyAndVersion.new("#{model_name}/2", 1)
+    m2v2 = ModelWithKeyAndVersion.new("#{model_name}/2", 2)
+
+    first_fetch_values  = @cache.fetch_multi(m1v1, m2v1) { |m| m.cache_key }
+    second_fetch_values = @cache.fetch_multi(m1v1, m2v2) { |m| m.cache_key + " 2nd" }
+
+    assert_equal({ m1v1 => "#{model_name}/1", m2v1 => "#{model_name}/2" }, first_fetch_values)
+    assert_equal({ m1v1 => "#{model_name}/1", m2v2 => "#{model_name}/2 2nd" }, second_fetch_values)
+  end
+
+  def test_version_is_normalized
+    key = SecureRandom.uuid
+    value = SecureRandom.alphanumeric
+
+    @cache.write(key, value, version: 1)
+    assert_equal value, @cache.read(key, version: "1")
+  end
+end

--- a/test/behaviors/encoded_key_cache_behavior.rb
+++ b/test/behaviors/encoded_key_cache_behavior.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# https://rails.lighthouseapp.com/projects/8994/tickets/6225-memcachestore-cant-deal-with-umlauts-and-special-characters
+# The error is caused by character encodings that can't be compared with ASCII-8BIT regular expressions and by special
+# characters like the umlaut in UTF-8.
+module EncodedKeyCacheBehavior
+  Encoding.list.each do |encoding|
+    define_method "test_#{encoding.name.underscore}_encoded_values" do
+      key = (+"foo_#{encoding.name.underscore}").force_encoding(encoding)
+      assert @cache.write(key, "1", raw: true)
+      assert_equal "1", @cache.read(key, raw: true)
+      assert_equal "1", @cache.fetch(key, raw: true)
+      assert @cache.delete(key)
+      assert_equal "2", @cache.fetch(key, raw: true) { "2" }
+      assert_equal 3, @cache.increment(key)
+      assert_equal 2, @cache.decrement(key)
+    end
+  end
+
+  def test_common_utf8_values
+    key = (+"\xC3\xBCmlaut").force_encoding(Encoding::UTF_8)
+    assert @cache.write(key, "1", raw: true)
+    assert_equal "1", @cache.read(key, raw: true)
+    assert_equal "1", @cache.fetch(key, raw: true)
+    assert @cache.delete(key)
+    assert_equal "2", @cache.fetch(key, raw: true) { "2" }
+    assert_equal 3, @cache.increment(key)
+    assert_equal 2, @cache.decrement(key)
+  end
+
+  def test_retains_encoding
+    key = (+"\xC3\xBCmlaut").force_encoding(Encoding::UTF_8)
+    assert @cache.write(key, "1", raw: true)
+    assert_equal Encoding::UTF_8, key.encoding
+  end
+end

--- a/test/behaviors/local_cache_behavior.rb
+++ b/test/behaviors/local_cache_behavior.rb
@@ -1,0 +1,309 @@
+# frozen_string_literal: true
+
+module LocalCacheBehavior
+  def test_instrumentation_with_local_cache
+    key = SecureRandom.uuid
+    events = with_instrumentation "write" do
+      @cache.write(key, SecureRandom.uuid)
+    end
+    assert_equal @cache.class.name, events[0].payload[:store]
+
+    @cache.with_local_cache do
+      events = with_instrumentation "read" do
+        @cache.read(key)
+        @cache.read(key)
+      end
+
+      expected = [@cache.class.name, @cache.send(:local_cache).class.name]
+      assert_equal expected, events.map { |p| p.payload[:store] }
+    end
+  end
+
+  def test_local_writes_are_persistent_on_the_remote_cache
+    key = SecureRandom.uuid
+    value = SecureRandom.alphanumeric
+    retval = @cache.with_local_cache do
+      @cache.write(key, value)
+    end
+    assert retval
+    assert_equal value, @cache.read(key)
+  end
+
+  def test_clear_also_clears_local_cache
+    key = SecureRandom.uuid
+    @cache.with_local_cache do
+      @cache.write(key, SecureRandom.alphanumeric)
+      @cache.clear
+      assert_nil @cache.read(key)
+    end
+
+    assert_nil @cache.read(key)
+  end
+
+  def test_clear_with_nil_options
+    key = SecureRandom.uuid
+    @cache.with_local_cache do
+      @cache.write(key, SecureRandom.alphanumeric)
+      @cache.clear(nil)
+      assert_nil @cache.read(key)
+    end
+
+    assert_nil @cache.read(key)
+  end
+
+  def test_cleanup_clears_local_cache_but_not_remote_cache
+    begin
+      @cache.cleanup
+    rescue NotImplementedError
+      skip
+    end
+
+    key = SecureRandom.uuid
+    value = SecureRandom.alphanumeric
+    other_value = SecureRandom.alphanumeric
+
+    @cache.with_local_cache do
+      @cache.write(key, value)
+      assert_equal value, @cache.read(key)
+
+      @cache.send(:bypass_local_cache) { @cache.write(key, other_value) }
+      assert_equal value, @cache.read(key)
+
+      @cache.cleanup
+      assert_equal other_value, @cache.read(key)
+    end
+  end
+
+  def test_local_cache_of_write
+    key = SecureRandom.uuid
+    value = SecureRandom.alphanumeric
+    @cache.with_local_cache do
+      @cache.write(key, value)
+      @peek.delete(key)
+      assert_equal value, @cache.read(key)
+    end
+  end
+
+  def test_local_cache_of_read_returns_a_copy_of_the_entry
+    key = SecureRandom.alphanumeric.to_sym
+    value = SecureRandom.alphanumeric
+    @cache.with_local_cache do
+      @cache.write(key, type: value)
+      local_value = @cache.read(key)
+      assert_equal(value, local_value.delete(:type))
+      assert_equal({ type: value }, @cache.read(key))
+    end
+  end
+
+  def test_local_cache_of_read
+    key = SecureRandom.uuid
+    value = SecureRandom.alphanumeric
+    @cache.write(key, value)
+    @cache.with_local_cache do
+      assert_equal value, @cache.read(key)
+    end
+  end
+
+  def test_local_cache_of_read_nil
+    key = SecureRandom.uuid
+    value = SecureRandom.alphanumeric
+    @cache.with_local_cache do
+      assert_nil @cache.read(key)
+      @cache.send(:bypass_local_cache) { @cache.write(key, value) }
+      assert_nil @cache.read(key)
+    end
+  end
+
+  def test_local_cache_fetch
+    key = SecureRandom.uuid
+    value = SecureRandom.alphanumeric
+    @cache.with_local_cache do
+      @cache.send(:local_cache).write_entry(key, value)
+      assert_equal value, @cache.send(:local_cache).fetch_entry(key)
+    end
+  end
+
+  def test_local_cache_of_write_nil
+    key = SecureRandom.uuid
+    value = SecureRandom.alphanumeric
+    @cache.with_local_cache do
+      assert @cache.write(key, nil)
+      assert_nil @cache.read(key)
+      @peek.write(key, value)
+      assert_nil @cache.read(key)
+    end
+  end
+
+  def test_local_cache_of_write_with_unless_exist
+    key = SecureRandom.uuid
+    value = SecureRandom.alphanumeric
+    @cache.with_local_cache do
+      @cache.write(key, value)
+      @cache.write(key, SecureRandom.alphanumeric, unless_exist: true)
+      assert_equal @peek.read(key), @cache.read(key)
+    end
+  end
+
+  def test_local_cache_of_delete
+    key = SecureRandom.uuid
+    @cache.with_local_cache do
+      @cache.write(key, SecureRandom.alphanumeric)
+      @cache.delete(key)
+      assert_nil @cache.read(key)
+    end
+  end
+
+  def test_local_cache_of_delete_matched
+    begin
+      @cache.delete_matched("*")
+    rescue NotImplementedError
+      skip
+    end
+
+    prefix = SecureRandom.alphanumeric
+    key = "#{prefix}#{SecureRandom.uuid}"
+    other_key = "#{prefix}#{SecureRandom.uuid}"
+    third_key = SecureRandom.uuid
+    value = SecureRandom.alphanumeric
+    @cache.with_local_cache do
+      @cache.write(key, SecureRandom.alphanumeric)
+      @cache.write(other_key, SecureRandom.alphanumeric)
+      @cache.write(third_key, value)
+      @cache.delete_matched("#{prefix}*")
+      assert_not @cache.exist?(key)
+      assert_not @cache.exist?(other_key)
+      assert_equal value, @cache.read(third_key)
+    end
+  end
+
+  def test_local_cache_of_exist
+    key = SecureRandom.uuid
+    @cache.with_local_cache do
+      @cache.write(key, SecureRandom.alphanumeric)
+      @peek.delete(key)
+      assert @cache.exist?(key)
+    end
+  end
+
+  def test_local_cache_of_increment
+    key = SecureRandom.uuid
+    @cache.with_local_cache do
+      @cache.write(key, 1, raw: true)
+      @peek.write(key, 2, raw: true)
+      @cache.increment(key)
+
+      expected = @peek.read(key, raw: true)
+      assert_equal 3, Integer(expected)
+      assert_equal expected, @cache.read(key, raw: true)
+    end
+  end
+
+  def test_local_cache_of_decrement
+    key = SecureRandom.uuid
+    @cache.with_local_cache do
+      @cache.write(key, 1, raw: true)
+      @peek.write(key, 3, raw: true)
+
+      @cache.decrement(key)
+      expected = @peek.read(key, raw: true)
+      assert_equal 2, Integer(expected)
+      assert_equal expected, @cache.read(key, raw: true)
+    end
+  end
+
+  def test_local_cache_of_fetch_multi
+    key = SecureRandom.uuid
+    other_key = SecureRandom.uuid
+    @cache.with_local_cache do
+      @cache.fetch_multi(key, other_key) { |_key| true }
+      @peek.delete(key)
+      @peek.delete(other_key)
+      assert_equal true, @cache.read(key)
+      assert_equal true, @cache.read(other_key)
+    end
+  end
+
+  def test_local_cache_of_read_multi
+    key = SecureRandom.uuid
+    value = SecureRandom.alphanumeric
+    other_key = SecureRandom.uuid
+    other_value = SecureRandom.alphanumeric
+    @cache.with_local_cache do
+      @cache.write(key, value, raw: true)
+      @cache.write(other_key, other_value, raw: true)
+      values = @cache.read_multi(key, other_key, raw: true)
+      assert_equal value, @cache.read(key, raw: true)
+      assert_equal other_value, @cache.read(other_key, raw: true)
+      assert_equal value, values[key]
+      assert_equal other_value, values[other_key]
+    end
+  end
+
+  def test_initial_object_mutation_after_write
+    key = SecureRandom.uuid
+    @cache.with_local_cache do
+      initial = +"bar"
+      @cache.write(key, initial)
+      initial << "baz"
+      assert_equal "bar", @cache.read(key)
+    end
+  end
+
+  def test_initial_object_mutation_after_fetch
+    key = SecureRandom.uuid
+    @cache.with_local_cache do
+      initial = +"bar"
+      @cache.fetch(key) { initial }
+      initial << "baz"
+      assert_equal "bar", @cache.read(key)
+      assert_equal "bar", @cache.fetch(key)
+    end
+  end
+
+  def test_middleware
+    key = SecureRandom.uuid
+    value = SecureRandom.alphanumeric
+    app = lambda { |env|
+      result = @cache.write(key, value)
+      assert_equal value, @cache.read(key) # make sure 'foo' was written
+      assert result
+      [200, {}, []]
+    }
+    app = @cache.middleware.new(app)
+    app.call({})
+  end
+
+  def test_local_race_condition_protection
+    key = SecureRandom.uuid
+    value = SecureRandom.alphanumeric
+    other_value = SecureRandom.alphanumeric
+    @cache.with_local_cache do
+      time = Time.now
+      @cache.write(key, value, expires_in: 60)
+      Time.stub(:now, time + 61) do
+        result = @cache.fetch(key, race_condition_ttl: 10) do
+          assert_equal value, @cache.read(key)
+          other_value
+        end
+        assert_equal other_value, result
+      end
+    end
+  end
+
+  def test_local_cache_should_read_and_write_false
+    key = SecureRandom.uuid
+    @cache.with_local_cache do
+      assert @cache.write(key, false)
+      assert_equal false, @cache.read(key)
+    end
+  end
+
+  def test_local_cache_should_deserialize_entries_on_multi_get
+    keys = Array.new(5) { SecureRandom.uuid }
+    values = keys.index_with(true)
+    @cache.with_local_cache do
+      assert @cache.write_multi(values)
+      assert_equal values, @cache.read_multi(*keys)
+    end
+  end
+end

--- a/test/composite_cache_store_test.rb
+++ b/test/composite_cache_store_test.rb
@@ -1,131 +1,49 @@
 # frozen_string_literal: true
 
 require_relative "test_helper"
+require "active_support/testing/method_call_assertions"
 
-class CompositeCacheStoreTest < ActiveSupport::TestCase
-  setup do
-    @logger = Logger.new("/dev/null") # used for Standard/Rubocop shenanigans
+require "active_support/cache"
+require_relative "behaviors/cache_store_behavior"
+require_relative "behaviors/cache_store_version_behavior"
+require_relative "behaviors/cache_store_coder_behavior"
+require_relative "behaviors/local_cache_behavior"
+require_relative "behaviors/cache_increment_decrement_behavior"
+require_relative "behaviors/cache_instrumentation_behavior"
+require_relative "behaviors/encoded_key_cache_behavior"
 
-    @store = CompositeCacheStore.new(
-      ActiveSupport::Cache::MemoryStore.new(expires_in: 1.second, size: 8.megabytes),
-      ActiveSupport::Cache::MemoryStore.new(expires_in: 1.minute, size: 64.megabytes)
-    )
-  end
+module CompositeCacheStoreTests
+  class StoreTest < ActiveSupport::TestCase
+    include ActiveSupport::Testing::MethodCallAssertions
 
-  test "default instantation" do
-    store = CompositeCacheStore.new
+    setup do
+      @logger = Logger.new("/dev/null") # used for Standard/Rubocop shenanigans
 
-    expected = {expires_in: 5.minutes, size: 16.megabytes, compress: false, compress_threshold: 1.kilobyte}
-    assert store.layers.first.is_a?(ActiveSupport::Cache::MemoryStore)
-    assert_equal expected, store.layers.first.options
-
-    expected = {expires_in: 1.day, size: 32.megabytes, compress: false, compress_threshold: 1.kilobyte}
-    assert store.layers.last.is_a?(ActiveSupport::Cache::MemoryStore)
-    assert_equal expected, store.layers.last.options
-  end
-
-  test "custom instantation" do
-    expected = {expires_in: 1.second, size: 8.megabytes, compress: false, compress_threshold: 1.kilobyte}
-    assert_equal expected, @store.layers.first.options
-
-    expected = {expires_in: 1.minute, size: 64.megabytes, compress: false, compress_threshold: 1.kilobyte}
-    assert_equal expected, @store.layers.last.options
-  end
-
-  test "invalid instantation" do
-    error = assert_raises(ArgumentError) do
-      CompositeCacheStore.new([], 1, true)
+      # NOTE: The inner cache store would normally use a shared persistence service like
+      #       Redis via ActiveSupport::Cache::RedisCacheStore
+      #
+      #       In a Rails app you might use Rails.cache as the inner cache store
+      @cache = CompositeCacheStore.new(
+        layers: [
+        ActiveSupport::Cache::MemoryStore.new(expires_in: 1.second, size: 8.megabytes),
+        ActiveSupport::Cache::MemoryStore.new(expires_in: 1.minute, size: 64.megabytes)]
+      )
     end
 
-    assert_equal "All layers must be instances of ActiveSupport::Cache::Store", error.message
-  end
-
-  test "write and read" do
-    @store.write(:test, "value")
-    assert_equal "value", @store.read(:test)
-    assert_equal "value", @store.layers.first.read(:test)
-    assert_equal "value", @store.layers.last.read(:test)
-  end
-
-  test "read rewrites to layer-1 cache on layer-1 cache miss" do
-    @store.write(:test, "value")
-    sleep 1
-    assert_nil @store.layers.first.read(:test) # layer-1 miss
-    assert_equal "value", @store.layers.last.read(:test) # layer-2 hit
-    assert_equal "value", @store.read(:test) # rewrites to layer-1
-    assert_equal "value", @store.layers.first.read(:test) # layer-1 hit
-  end
-
-  test "write_multi and read_multi" do
-    hash = {a: 1, b: 2, c: 3}
-    @store.write_multi(hash)
-    assert_equal hash, @store.read_multi(:a, :b, :c)
-    assert_equal hash, @store.layers.first.read_multi(:a, :b, :c)
-    assert_equal hash, @store.layers.last.read_multi(:a, :b, :c)
-  end
-
-  test "read_multi rewrites to layer-1 cache on layer-1 cache miss" do
-    hash = {a: 1, b: 2, c: 3}
-    @store.write_multi(hash)
-    sleep 1
-    assert @store.layers.first.read_multi(:a, :b, :c).blank?
-    assert_equal hash, @store.layers.last.read_multi(:a, :b, :c)
-    assert_equal hash, @store.read_multi(:a, :b, :c)
-    assert_equal hash, @store.layers.first.read_multi(:a, :b, :c)
-  end
-
-  test "fetch" do
-    @store.fetch(:test) do
-      @logger.debug "Prevent Standard/Rubocop from jacking up the fetch block ¯\\_(ツ)_/¯"
-      "value"
+    def lookup_store(options = {})
+      # TODO in case of upstreaming to Rails, add active_support/cache/composite_cache_store
+      # ActiveSupport::Cache.lookup_store(:composite_cache_store, options)
+      @cache
     end
-    assert_equal "value", @store.read(:test)
-    assert_equal "value", @store.layers.first.read(:test)
-    assert_equal "value", @store.layers.last.read(:test)
   end
 
-  test "fetch rewrites to layer-1 cache on layer-1 cache miss" do
-    @store.write(:test, "value")
-    sleep 1
-    assert_nil @store.layers.first.read(:test) # layer-1 miss
-    assert_equal "value", @store.layers.last.read(:test) # layer-2 hit
-    @store.fetch(:test) do # rewrites layer-1
-      @logger.debug "Prevent Standard/Rubocop from jacking up the fetch block ¯\\_(ツ)_/¯"
-      "value"
-    end
-    assert_equal "value", @store.layers.first.read(:test) # layer-1 hit
-  end
-
-  test "delete" do
-    @store.write(:test, "value")
-    assert_equal "value", @store.read(:test)
-    assert_equal "value", @store.layers.first.read(:test)
-    assert_equal "value", @store.layers.last.read(:test)
-    @store.delete(:test)
-    assert_nil @store.read(:test)
-    assert_nil @store.layers.first.read(:test)
-    assert_nil @store.layers.last.read(:test)
-  end
-
-  test "applies expires_in when value is less than store's configured expires_in" do
-    @store.write(:test, "value", expires_in: 0.1.seconds)
-    assert_equal "value", @store.read(:test)
-    assert_equal "value", @store.layers.first.read(:test)
-    assert_equal "value", @store.layers.last.read(:test)
-    sleep 0.1
-    assert_nil @store.read(:test)
-    assert_nil @store.layers.first.read(:test)
-    assert_nil @store.layers.last.read(:test)
-  end
-
-  test "applies expires_at when computed expires_in is less than store's configured expires_in" do
-    @store.write(:test, "value", expires_at: 0.1.second.from_now)
-    assert_equal "value", @store.read(:test)
-    assert_equal "value", @store.layers.first.read(:test)
-    assert_equal "value", @store.layers.last.read(:test)
-    sleep 0.1
-    assert_nil @store.read(:test)
-    assert_nil @store.layers.first.read(:test)
-    assert_nil @store.layers.last.read(:test)
+  class CompositeCacheStoreCommonBehaviorTest < StoreTest
+    include CacheStoreBehavior
+    include CacheStoreVersionBehavior
+    # include CacheStoreCoderBehavior
+    # include LocalCacheBehavior
+    # include CacheIncrementDecrementBehavior
+    include CacheInstrumentationBehavior
+    # include EncodedKeyCacheBehavior
   end
 end


### PR DESCRIPTION
Using [cache behavior tests](https://github.com/rails/rails/tree/main/activesupport/test/cache/behaviors) from ActiveSupport for maximum compatibility and safety.

Note that I copied them over because I didn't see any other way to include those private modules in our codebase, but this will guarantee we _could_ make upstreaming attempts in the future.

I noticed that most cache store implementations only implement a subset of methods (`read_entry`, `write_entry`, `delete_entry`), while `fetch`, `fetch_multi` and others delegate to those. Note that some of my implementations are deliberately naive here, I thought it would be worthwhile getting to know the Rails cache store API better first. We can always make more optimizations later.

Some obscure test cases from `CacheStoreBehavior` are still failing, but mostly it looks good. Especially this looks weird:

```
Minitest::UnexpectedError:         NoMethodError: undefined method `raise_on_invalid_cache_expiration_time=' for ActiveSupport::Cache::Store:Class

            ActiveSupport::Cache::Store.raise_on_invalid_cache_expiration_time = old_value
                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```