### PR TITLE
Add support for Rails 8.0 and test all supported Rails version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,36 +1,65 @@
 name: Tests
 
-on:
-  pull_request:
-    branches:
-      - '*'
-  push:
-    branches:
-      - main
+on: [push, pull_request]
 
 jobs:
   ruby_test:
-    name: Ruby Test Action
+    name: "Test ruby:${{matrix.ruby}} rails:${{matrix.rails}} ${{matrix.os}}"
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        ruby-version: ['2.7', '3.0', '3.1', '3.2']
+        os:
+          - ubuntu-latest
+          #- macos-latest
+          #- windows-latest
+        ruby:
+          - '2.7'
+          - '3.0'
+          - '3.1'
+          - '3.2'
+          - '3.3'
+          - '3.4'
+          #- jruby-9.4
+          #- truffleruby
+        rails:
+          - '6.0.6.1'
+          - '6.1.7.10'
+          - '7.0.8.7'
+          - '7.1.5.1'
+          - '7.2.2.1'
+          - '8.0.2'
+        exclude:
+          - os: windows-latest
+            ruby: jruby
+          - os: windows-latest
+            ruby: truffleruby
+          - rails: '6.0.6.1'
+            ruby: '3.4'
+          - rails: '6.1.7.10'
+            ruby: '3.4'
+          - rails: '7.0.8.7'
+            ruby: '3.4'
+          - rails: '7.2.2.1'
+            ruby: '2.7'
+          - rails: '7.2.2.1'
+            ruby: '3.0'
+          - rails: '8.0.2'
+            ruby: '2.7'
+          - rails: '8.0.2'
+            ruby: '3.0'
+          - rails: '8.0.2'
+            ruby: '3.1'
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Ruby ${{ matrix.ruby-version }}
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby-version }}
-    - uses: actions/cache@v3
-      with:
-        path: vendor/bundle
-        key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-gems-
-    - name: Bundle install
-      run: |
-        gem install bundler
-        bundle config path vendor/bundle
-        bundle install --jobs 4 --retry 3
-    - name: Run ruby tests
-      run: bundle exec rake test
+      - uses: actions/checkout@v3
+      - name: Set up Ruby ${{ matrix.ruby }}
+        uses: ruby/setup-ruby@v1
+        env:
+          RAILS_VERSION: ${{ matrix.rails }}
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - name: Run ruby tests
+        env:
+          RAILS_VERSION: ${{ matrix.rails }}
+        run: bundle exec rake test

--- a/Gemfile
+++ b/Gemfile
@@ -3,13 +3,20 @@
 source "https://rubygems.org"
 
 if ENV["GITHUB_ACTIONS"] || ENV["COMPOSITE_CACHE_STORE_ENV"] == "test"
-  git "https://github.com/rails/rails.git" do
-    if ENV["RAILS_VERSION"]
-      gem "activesupport", require: "active_support", tag: ENV["RAILS_VERSION"]
-    else
-      gem "activesupport", require: "active_support"
-    end
+  git "https://github.com/rails/rails.git", tag: ENV["RAILS_VERSION"]&.gsub(/\Av?/, 'v') do
+    gem "activesupport", require: "active_support"
   end
+
+  # Hack to fix Rails 6.x and 7.0
+  # https://stackoverflow.com/questions/79360526/uninitialized-constant-activesupportloggerthreadsafelevellogger-nameerror
+  if ENV["RAILS_VERSION"]&.match?(/\A\D*?(?:6|7\.0)(?:\.|\z)/)
+    gem 'concurrent-ruby', '1.3.4'
+  end
+
+  # Load gems removed from Ruby kernel
+  gem 'base64'
+  gem 'mutex_m'
+  gem 'drb'
 end
 
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -6,9 +6,12 @@ require "paint"
 
 # versions of rails to test against
 rails_versions = %w[
-  v5.2.8.1
-  v6.1.7.3
-  v7.0.4.3
+  6.0.6.1
+  6.1.7.10
+  7.0.8.7
+  7.1.5.1
+  7.2.2.1
+  8.0.2
   edge
 ]
 
@@ -20,20 +23,28 @@ end
 
 task :test do
   ENV["COMPOSITE_CACHE_STORE_ENV"] = "test"
-  rails_versions.each do |rails_version|
-    ENV["RAILS_VERSION"] = (rails_version == "edge") ? nil : rails_version
-    puts Paint % ["Bundling activesupport %{version} from github ", :blue, :underline, version: [rails_version, "sky blue", :underline]]
-    print Paint["required for tests provided by rails... ", "slate gray"]
-    `bundle update activesupport`
-    puts "done!\n\n"
+
+  if ENV["RAILS_VERSION"]
     Rake::Task["minitest"].invoke
-    Rake::Task["minitest"].reenable unless rails_version == rails_versions.last
+    return
   end
-ensure
-  if ENV["GITHUB_ACTIONS"] != "true"
-    ENV["COMPOSITE_CACHE_STORE_ENV"] = nil
-    print Paint["Restoring bundle with activesupport from rubygems... ", :blue]
-    `bundle update activesupport`
-    puts "done!"
+
+  begin
+    rails_versions.each do |rails_version|
+      ENV["RAILS_VERSION"] = (rails_version == "edge") ? nil : rails_version
+      puts Paint % ["Bundling activesupport %{version} from github ", :blue, :underline, version: [rails_version, "sky blue", :underline]]
+      print Paint["required for tests provided by rails... ", "slate gray"]
+      `bundle update activesupport`
+      puts "done!\n\n"
+      Rake::Task["minitest"].invoke
+      Rake::Task["minitest"].reenable unless rails_version == rails_versions.last
+    end
+  ensure
+    if ENV["GITHUB_ACTIONS"] != "true"
+      ENV["COMPOSITE_CACHE_STORE_ENV"] = nil
+      print Paint["Restoring bundle with activesupport from rubygems... ", :blue]
+      `bundle update activesupport`
+      puts "done!"
+    end
   end
 end

--- a/lib/composite_cache_store.rb
+++ b/lib/composite_cache_store.rb
@@ -111,12 +111,20 @@ class CompositeCacheStore
 
   def increment(name, amount = 1, options = nil)
     provisional_layers.each { |layer| layer.delete(name, options) }
-    layers.last.increment(name, amount, options)
+    if ActiveSupport.version.to_s >= '8'
+      layers.last.increment(name, amount, **options)
+    else
+      layers.last.increment(name, amount, options)
+    end
   end
 
   def decrement(name, amount = 1, options = nil)
     provisional_layers.each { |layer| layer.delete(name, options) }
-    layers.last.decrement(name, amount, options)
+    if ActiveSupport.version.to_s >= '8'
+      layers.last.decrement(name, amount, **options)
+    else
+      layers.last.decrement(name, amount, options)
+    end
   end
 
   def cleanup(...)


### PR DESCRIPTION
Changes in this PR:
- Add support for Rails 8.0
- Adds test coverage for all supported Rails versions

I've reworked how tests are done a bit, in this PR I'm doing a unique Github Actions run per ActiveSupport version, which makes it a lot easier to track down issues.

However, it seems there are about 5 tests from the ActiveSupport suite failing on all versions, and I don't have time at the moment to track down why.